### PR TITLE
deprecation period

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -20,6 +20,7 @@ const routers = [
 // requires postgres server
 if (process.env.NAMESTONE_PG) {
 	routers.push((await import('./routers/namestone-pg.js')).default);
+	routers.push((await import("./routers/namestone-pg-old.js")).default);
 }
 
 // (optional) this exposes the other routers as subdomains

--- a/routers/namestone-pg-old.js
+++ b/routers/namestone-pg-old.js
@@ -12,7 +12,7 @@ const record_cache = new SmartCache();
 const RECORD_CACHE_MS = 15000;
 
 export default {
-	slug: 'namestone-pg',
+	slug: 'pg',
 	async resolve(name) { 
 		const MIN = 2; // currently every domain is "a.b"
 		let labels = name.split('.');


### PR DESCRIPTION
- We have users currently using 'pg' as the endpoint for dns, so we're creating a new namestone-pg-old router that hosts 'pg' endpoint till they move
- We might have other sources of data in the future so changing endpoint from namestone -> namestone-pg